### PR TITLE
chore: deploy mcp-docs to vercel and wire vscode mcp config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/mcp.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "dep-incubation-docs": {
+      "type": "http",
+      "url": "https://dep-incubation-mcp-docs.vercel.app"
+    }
+  }
+}

--- a/apps/mcp-docs/package.json
+++ b/apps/mcp-docs/package.json
@@ -9,6 +9,7 @@
     "dev": "tsx src/server.ts"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.0.0"
   }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "apps/mcp-docs/api/mcp.ts",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "/apps/mcp-docs/api/mcp.ts" }
+  ]
+}


### PR DESCRIPTION
- Add root vercel.json to deploy apps/mcp-docs from repo root so .docs/ is included
- Add @types/node to apps/mcp-docs devDependencies (required for Vercel build)
- Add .vscode/mcp.json pointing at https://dep-incubation-mcp-docs.vercel.app
- Whitelist .vscode/mcp.json in .gitignore so it is committed to repo